### PR TITLE
fix: add a missing comma to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"mysql2": "^3.9.1"
+		"mysql2": "^3.9.1",
 		"@popperjs/core": "^2.11.8",
 		"flowbite": "^2.3.0",
 		"flowbite-svelte": "^0.44.23",


### PR DESCRIPTION
When I merged `package.json`, I forgot to put a comma after one of the dependencies, causing an error. Apologies!