### PR TITLE
fix: remove symbol for password validation

### DIFF
--- a/src/lib/components/RegisterForm.svelte
+++ b/src/lib/components/RegisterForm.svelte
@@ -203,7 +203,7 @@
                     type="password" 
                     id="password" 
                     pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{'{'}8,{'}'}"
-                    title="Please enter at least one lowercase letter, uppercase letter, symbol, and number."
+                    title="Please enter at least one lowercase letter, uppercase letter, and number."
                     placeholder="••••••••" 
                     required 
                 />


### PR DESCRIPTION
Per Allaine's request, I removed the symbol as a requirement for password in student registration.