### PR TITLE
feat/frontend/delete: working delete button in the UI and reflects changes in the UI

### DIFF
--- a/src/lib/components/Table.svelte
+++ b/src/lib/components/Table.svelte
@@ -39,9 +39,32 @@
     }
 
     const dispatch = createEventDispatcher<{submit:any}>()
+    const dispatchDelete = createEventDispatcher<{delete:any}>()
 
     const submitFormHandle = async (a: any) => {
         dispatch('submit', a.detail);
+    }
+
+    const deleteEntryHandle = async (a: any) => {
+        dispatchDelete('delete', a.detail);
+        console.log(a.detail);
+
+        const primaryKeyDelete = a.detail[primaryKey];
+        console.log(primaryKeyDelete)
+
+        const index = information.findIndex((entry: { [key: string]: any }) => 
+            entry[primaryKey] === primaryKeyDelete
+        );
+
+        if (index !== -1) {
+            information.splice(index, 1);
+        }
+
+        update()
+    };
+
+    function update(){
+        information = information;
     }
 
 </script>
@@ -50,7 +73,7 @@
     <TableHeader headers={headers} bind:sortKey bind:sortDirection isEditing={isEditing}/>
     <TableBody>
         {#each $sortedItems as info}
-            <TableRow on:submit={submitFormHandle} info={info} primaryKey={primaryKey} bind:isEditing/>
+            <TableRow on:delete={deleteEntryHandle} on:submit={submitFormHandle} info={info} primaryKey={primaryKey} bind:isEditing/>
         {/each}
     </TableBody>
 </Table>

--- a/src/lib/components/TableRow.svelte
+++ b/src/lib/components/TableRow.svelte
@@ -7,6 +7,7 @@
 
     import TableCell from "./TableCell.svelte";
     import Input from "./Input.svelte";
+    import Button from "./Button.svelte"
 
     export let info: any;
     export let primaryKey: string;
@@ -59,6 +60,7 @@
     //function for submitting the formData
     const dispatch = createEventDispatcher<{submit:any}>()
     let isSubmitting = false
+
     const submitForm = async () => {
         isSubmitting = true;
         const payload:any = {};
@@ -75,6 +77,10 @@
             primaryKeyEdit = null;
         }
         isSubmitting = false;
+    }
+
+    const deleteEntry = async() => {
+
     }
 </script>
 
@@ -135,7 +141,19 @@
 
 <Modal bind:open={popupModal} size="xs" autoclose>
     <div class="text-center">
-      <h3 class="mb-5 text-lg font-normal text-gray-500 dark:text-gray-400">Are you sure you want to delete this product?</h3>
+        <p class="text-[#131416] font-bold">Are you sure you want to delete this entry?</p>
+        <p>This cannot be undone.</p>
+        {#each Object.entries(info) as [field, value], index}
+            {#if field !== "isEnrolled"}
+                <span> {value}, </span>
+            {/if}
+        {/each}
+    </div>
+
+    <!-- Action buttons -->
+    <div class="flex justify-center gap-4">
+        <Button inverse={true}>Cancel</Button>
+        <Button icon="delete">Delete</Button>
     </div>
 </Modal>
 

--- a/src/lib/components/TableRow.svelte
+++ b/src/lib/components/TableRow.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { createEventDispatcher } from "svelte";
-    import { TableBodyRow, TableBodyCell, Checkbox } from "flowbite-svelte";
+    import { TableBodyRow, TableBodyCell, Modal } from "flowbite-svelte";
     import { Check, XMark, Icon, Pencil, Trash } from "svelte-hero-icons";
 
     import { getKey } from "$lib/utils/utils";
@@ -11,6 +11,8 @@
     export let info: any;
     export let primaryKey: string;
     export let isEditing: boolean = false;
+    let popupModal = false;
+
     
     // for edit
     let primaryKeyEdit: string | number | null = null;
@@ -118,7 +120,9 @@
         <!-- action buttons -->
         <div class="flex p-5 gap-4 group-hover:visible invisible pl-20 sticky right-0 bg-gradient-to-l from-white via-white to-transparent -ml-[100px]">
             <!-- generate the action buttons -->
-            <a href="/tables" class="font-medium text-red-600"><Icon src="{Trash}" micro size="20"/></a>
+            <button on:click={() => (popupModal = true)} class="font-medium text-red-600">
+                <Icon src="{Trash}" micro size="20"/>
+            </button>
             {#if info.hasOwnProperty("isEnrolled") && info.isEnrolled == "0"}
                 <a href="/tables" class="font-medium text-green-800"><Icon src="{Check}" micro size="20"/></a>
             {/if}
@@ -128,6 +132,12 @@
         </div>
     {/if}
 </TableBodyRow>
+
+<Modal bind:open={popupModal} size="xs" autoclose>
+    <div class="text-center">
+      <h3 class="mb-5 text-lg font-normal text-gray-500 dark:text-gray-400">Are you sure you want to delete this product?</h3>
+    </div>
+</Modal>
 
 <style lang="postcss">
     @tailwind components;

--- a/src/lib/components/TableRow.svelte
+++ b/src/lib/components/TableRow.svelte
@@ -79,8 +79,12 @@
         isSubmitting = false;
     }
 
-    const deleteEntry = async() => {
+    const dispatchDelete = createEventDispatcher<{delete:any}>()
 
+    function deleteEntry( primaryKeyDelete: string ) {
+        const payload:any = {};
+        payload[primaryKey] = primaryKeyDelete;
+        dispatchDelete('delete', payload);
     }
 </script>
 
@@ -153,7 +157,7 @@
     <!-- Action buttons -->
     <div class="flex justify-center gap-4">
         <Button inverse={true}>Cancel</Button>
-        <Button icon="delete">Delete</Button>
+        <Button on:click={() => deleteEntry(getKey(info, primaryKey))} icon="delete">Delete</Button>
     </div>
 </Modal>
 

--- a/src/routes/dashboard/students/+page.svelte
+++ b/src/routes/dashboard/students/+page.svelte
@@ -28,6 +28,10 @@
 		console.log(a.detail);
 	}
 
+	function onDelete (a: any){
+		console.log(a.detail);
+	}
+
 </script>
 
-<Table on:submit={onCommand} headers={headers} information = {students} primaryKey="studentNumber"/>
+<Table on:delete={onDelete} on:submit={onCommand} headers={headers} information = {students} primaryKey="studentNumber"/>


### PR DESCRIPTION
- Clicking the delete button now opens a pop-up (will fix styles in a different PR). Clicking cancel will close the modal and clicking delete will delete the entry in the frontend. (Refreshing will reset the table because it's not yet connected to the backend)
- Pressing delete forwards the primary key to +page.svelte

![image](https://github.com/bbcarrots/SUSe/assets/56602966/2751e619-69d6-414a-a4a3-9a7d3584d559)
![image](https://github.com/bbcarrots/SUSe/assets/56602966/eeae4354-2938-412a-9c25-96b2313ba06e)
