### PR TITLE
fix/backend/usagelog: corrected return values

### DIFF
--- a/src/lib/classes/UsageLog.ts
+++ b/src/lib/classes/UsageLog.ts
@@ -9,18 +9,20 @@ export type UsageLogDBObj = {
 	ul_id: number;
 	sn_id: number;
 	admin_id: number;
+    service_id: number;
 	service_type: string;
 	datetime_start: string;
 	datetime_end: string;
 };
 
 export type UsageLogUIObj = {
-	usageLogID: number;
+	usageLogId: number;
 	studentNumber: number;
-	AdminID: number;
-	ServiceType: string;
-	DateTimeIn: Date;
-	DateTimeOut: Date;
+	adminId: number;
+    serviceId: number;
+	serviceType: string;
+	dateTimeIn: Date;
+	dateTimeOut: Date;
 };
 
 export type UsageLogResponse = {
@@ -41,24 +43,26 @@ export class UsageLog {
 	public static toUsageLogUIObj(log: UsageLogDBObj): UsageLogUIObj {
 		/* Converts a UsageLogDBObj to a UsageLogUIObj. */
 		return {
-			usageLogID: log.ul_id,
+			usageLogId: log.ul_id,
 			studentNumber: log.sn_id,
-			AdminID: log.admin_id,
-			ServiceType: log.service_type,
-			DateTimeIn: new Date(log.datetime_start),
-			DateTimeOut: new Date(log.datetime_end)
+			adminId: log.admin_id,
+            serviceId: log.service_id,
+			serviceType: log.service_type,
+			dateTimeIn: new Date(log.datetime_start),
+			dateTimeOut: new Date(log.datetime_end)
 		};
 	}
 
-	public static toSUsageLogDBObj(log: UsageLogUIObj): UsageLogDBObj {
+	public static toUsageLogDBObj(log: UsageLogUIObj): UsageLogDBObj {
 		/* Converts a UsageLogUIObj to a UsageLogUIObj. */
 		return {
-			ul_id: log.usageLogID,
+			ul_id: log.usageLogId,
 			sn_id: log.studentNumber,
-			admin_id: log.AdminID,
-			service_type: log.ServiceType,
-			datetime_start: new Date(log.DateTimeIn).toISOString(),
-			datetime_end: new Date(log.DateTimeOut).toISOString()
+			admin_id: log.adminId,
+            service_id: log.serviceId,
+			service_type: log.serviceType,
+			datetime_start: new Date(log.dateTimeIn).toISOString(),
+			datetime_end: new Date(log.dateTimeOut).toISOString()
 		};
 	}
 

--- a/src/lib/classes/UsageLog.ts
+++ b/src/lib/classes/UsageLog.ts
@@ -61,8 +61,8 @@ export class UsageLog {
 			admin_id: log.adminId,
             service_id: log.serviceId,
 			service_type: log.serviceType,
-			datetime_start: new Date(log.dateTimeIn).toISOString(),
-			datetime_end: new Date(log.dateTimeOut).toISOString()
+			datetime_start: log.dateTimeIn.toISOString(),
+			datetime_end: log.dateTimeOut.toISOString()
 		};
 	}
 

--- a/src/lib/server/UsageLogSB.ts
+++ b/src/lib/server/UsageLogSB.ts
@@ -18,12 +18,16 @@ export async function selectUsageLogDB(filter: UsageLogFilter): Promise<UsageLog
 	/* Selects the usage logs/s from the database using a filter.
     Filter only contains option for date start and end for now. */
 
-	let query = supabase.from('usage_log').select('*');
+	let query = supabase
+		.from('usage_log')
+		.select('ul_id, sn_id, admin_id, datetime_start, datetime_end, service ( service_id, service_type ( service_type ) )');
 
-	if (filter.usageLogID) { // if there is a given usageLogID, search for that
+	if (filter.usageLogID) {
+		// if there is a given usageLogID, search for that
 		query = query.eq('ul_id', filter.usageLogID);
 	}
-	if (filter.minDate && filter.maxDate) { // if there is a given start and end date range, search for that
+	if (filter.minDate && filter.maxDate) {
+		// if there is a given start and end date range, search for that
 		query = query.gte('datetime_start', filter.minDate).lte('datetime_end', filter.maxDate);
 	}
 
@@ -37,9 +41,23 @@ export async function selectUsageLogDB(filter: UsageLogFilter): Promise<UsageLog
 		};
 	}
 
+	const formattedData: UsageLogDBObj[] = [];
+
+	for (const row of data) {
+		formattedData.push({
+			ul_id: row.ul_id,
+			sn_id: row.sn_id,
+			admin_id: row.admin_id,
+			service_id: row.service.service_id, // will fix later after tinkering with supabase type returns
+			service_type: row.service.service_type.service_type, // we assume each service only has one service_type
+			datetime_start: row.datetime_start,
+			datetime_end: row.datetime_end
+		});
+	}
+
 	return {
 		success: true,
-		usageLogRaws: data,
+		usageLogRaws: formattedData,
 		error: null
 	};
 }


### PR DESCRIPTION
Just updated the return values of `selectUsageLogDB` to get the `service_type` by joining `usage_log`, `service` and `service_type` tables.