### PR TITLE
feat/frontend/rfid: add input field for rfid scanner

### DIFF
--- a/src/app.pcss
+++ b/src/app.pcss
@@ -29,7 +29,7 @@ h3 {
 }
 
 h4 {
-	font-size: 24px;
+	font-size: 20px;
 	font-weight: 300;
 	line-height: 140%;
 }
@@ -41,7 +41,7 @@ h5 {
 }
 
 p {
-	font-size: 14px;
+	font-size: 16px;
 	font-weight: 300;
 	line-height: 140%;
 }

--- a/src/lib/components/Button.svelte
+++ b/src/lib/components/Button.svelte
@@ -14,7 +14,7 @@
 
 <button 
     type={submit ? 'submit' : 'button'}
-    class="flex gap-2 py-3 px-6 rounded-md hover:bg-suse-black/95 font-medium text-sm inline-flex items-center
+    class="w-full justify-center gap-2 py-3 px-6 rounded-md hover:bg-suse-black/95 font-medium text-sm inline-flex items-center
         {inverse ? 'bg-transparent text-suse-black border border-suse-black border-solid hover:bg-suse-black/40' : 'bg-suse-black text-suse-white'}
         {small ? 'py-2 px-4' : 'py-3 px-6'}
         {disabled ? 'opacity-50 pointer-events-none' : ''}"

--- a/src/lib/components/LoginForm.svelte
+++ b/src/lib/components/LoginForm.svelte
@@ -1,6 +1,54 @@
 <script lang="ts">
+    import { onMount } from "svelte";
     import Button from "./Button.svelte";    
+
+    //to determine which login to display
     let rfidLogin = true;
+
+    onMount(() => {
+
+        const handleClickOutside = (e: any) => {
+            const rfidInput = document.getElementById('rfidInput'); //take the rfid input
+            const target = e.target;    //take the target of the event
+            const focusedElement = document.activeElement;  //this is the active element being focused
+            console.log(rfidInput, focusedElement)
+
+            // if the current element is rfidInput and you are not clicking an input or a button, do not remove the focus
+            if (focusedElement === rfidInput && !(target instanceof HTMLInputElement || target instanceof HTMLButtonElement)) {
+                e.preventDefault();
+            }
+
+            // if the current element is not the rfidInput and you click anything else, it should focus the rfid input
+            else if(focusedElement !== rfidInput && !(target instanceof HTMLInputElement || target instanceof HTMLButtonElement)) {
+
+                //need to add a delay because of svelte
+                setTimeout(() => {
+                    rfidInput?.focus()
+                }, 10)
+            }  
+        };
+        
+        const handleKeyDown = (e: any) => {
+            const rfidInput = document.getElementById('rfidInput'); //take the rfid input
+            const focusedElement = document.activeElement;  //this is the active element being focused
+
+            if (rfidInput === focusedElement){
+                console.log()
+                e.preventDefault();
+            }
+        }
+
+        // when mouse is clicked, call handle click outside
+        document.addEventListener('mousedown', handleClickOutside);
+
+        // when keyboard is pressed, call handle key down
+        document.addEventListener('keydown', handleKeyDown);
+
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    });
 
     function handleChangeToUsername() {
         rfidLogin = false;
@@ -26,6 +74,9 @@
             <button on:click={handleChangeToUsername} class="text-blue-600">Login using username and password to view available services</button>
         <div class="flex-grow border-t bg-suse-black/50"></div>
     </div>
+
+    <input id="rfidInput" autofocus/>
+
     {:else}
 
     <!-- FORM -->

--- a/src/lib/components/LoginForm.svelte
+++ b/src/lib/components/LoginForm.svelte
@@ -59,64 +59,76 @@
     }
 </script>
 
-<section class="grid gap-y-8">
+<section class="grid gap-y-8 h-full w-full items-center justify-center">
 
     {#if rfidLogin == true}
-    <!-- HEADER -->
-    <div class="grid text-center gap-4">
-        <h1>Tap your UP ID to log in or register</h1>
-        <p>Avail Engglib services using SUSê by tapping your RFID!</p>    
-    </div>
-    
-    <div class="relative flex items-center">
-        <div class="flex-grow border-t bg-suse-black/50"></div>
-        <!-- <span class="flex-shrink mx-2 text-suse-black/50"><p>or view available services by logging in via username</p></span> -->
-            <button on:click={handleChangeToUsername} class="text-blue-600">Login using username and password to view available services</button>
-        <div class="flex-grow border-t bg-suse-black/50"></div>
-    </div>
 
-    <input id="rfidInput" autofocus/>
+    <!-- HEADER -->
+     <div class="grid text-center gap-6">
+        <div class="grid gap-4">
+            <h1>Tap your UP ID to log in or register</h1>
+            <h4>Avail Engglib services using SUSê by tapping your RFID!</h4>         
+        </div>
+
+        <button on:click={handleChangeToUsername} class="text-blue-600"><p>Login using username</p></button>
+
+        <input id="rfidInput" autofocus/>
+    </div>  
+
 
     {:else}
 
     <!-- FORM -->
-    <form class="grid gap-y-4" method="POST">
-
-           <!-- email section -->
-           <div class="grid gap-y-2">
-            <div class="flex">
-                <input 
-                    name="username"
-                    type="text" 
-                    id="email" 
-                    placeholder="Username"
-                    pattern="[A-Za-z0-9]+" 
-                    title="Please only enter alphabets"
-                    required
-                />
-            </div>
+    <div class="grid text-center gap-6">
+        <div class="grid gap-4">
+            <h1>Log in using username</h1>
+            <h4>to view all available services</h4> 
         </div>
+   
+        <div class="relative flex">
+            <form class="grid gap-y-4 flex-grow" method="POST">
 
-        <!-- password section-->
-        <div class="grid gap-y-2">
-            <input 
-                name="password"
-                type="password" 
-                id="password" 
-                title="Please enter at least one lowercase letter, uppercase letter, and number."
-                placeholder="Password" 
-                required 
-            />
-            <span>
+                <!-- email section -->
+                <div class="grid gap-y-2">
+                    <div class="flex">
+                        <input 
+                            name="username"
+                            type="text" 
+                            id="email" 
+                            placeholder="Username"
+                            pattern="[A-Za-z0-9]+" 
+                            title="Please only enter alphabets"
+                            required
+                        />
+                    </div>
+                </div>
+
+                <!-- password section-->
+                <div class="grid gap-y-2">
+                    <input 
+                        name="password"
+                        type="password" 
+                        id="password" 
+                        title="Please enter at least one lowercase letter, uppercase letter, and number."
+                        placeholder="Password" 
+                        required 
+                    />
+                    <span>
+                </div>
+
+                <!-- ACTION BUTTONS -->
+                <div class="inline-flex gap-4">
+                    <div class="flex-grow">
+                        <Button submit={true}> Login </Button>
+
+                    </div>
+                </div>
+                <button on:click={handleChangeToRFID} class="text-blue-600"><p>Login using RFID</p></button>
+
+            </form>
         </div>
+    </div>
 
-        <!-- ACTION BUTTONS -->
-        <div class="inline-flex gap-4">
-            <Button submit={true}> Login </Button>
-        </div>
-        <button on:click={handleChangeToRFID} class="text-blue-600">Login using RFID to avail services</button>
-
-    </form>
     {/if}
 </section>
 

--- a/src/lib/components/LoginForm.svelte
+++ b/src/lib/components/LoginForm.svelte
@@ -1,20 +1,32 @@
 <script lang="ts">
     import Button from "./Button.svelte";    
+    let rfidLogin = true;
+
+    function handleChangeToUsername() {
+        rfidLogin = false;
+    }
+
+    function handleChangeToRFID() {
+        rfidLogin = true;
+    }
 </script>
 
 <section class="grid gap-y-8">
 
+    {#if rfidLogin == true}
     <!-- HEADER -->
     <div class="grid text-center gap-4">
-        <h1>Tap your UP ID to log in/register</h1>
+        <h1>Tap your UP ID to log in or register</h1>
         <p>Avail Engglib services using SUSê by tapping your RFID!</p>    
     </div>
     
     <div class="relative flex items-center">
         <div class="flex-grow border-t bg-suse-black/50"></div>
-        <span class="flex-shrink mx-2 text-suse-black/50"><p>or view available services by logging in via username</p></span>
+        <!-- <span class="flex-shrink mx-2 text-suse-black/50"><p>or view available services by logging in via username</p></span> -->
+            <button on:click={handleChangeToUsername} class="text-blue-600">Login using username and password to view available services</button>
         <div class="flex-grow border-t bg-suse-black/50"></div>
     </div>
+    {:else}
 
     <!-- FORM -->
     <form class="grid gap-y-4" method="POST">
@@ -51,9 +63,10 @@
         <div class="inline-flex gap-4">
             <Button submit={true}> Login </Button>
         </div>
-  
-    </form>
+        <button on:click={handleChangeToRFID} class="text-blue-600">Login using RFID to avail services</button>
 
+    </form>
+    {/if}
 </section>
 
 <style lang="postcss">

--- a/src/lib/utils/types.ts
+++ b/src/lib/utils/types.ts
@@ -30,3 +30,4 @@ export type ServiceProcessed = {
 export type AdminProcessed = {
 	adminID: number;
 	nickname: string;
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,11 +2,46 @@
     import Button from "$lib/components/Button.svelte";
     import LoginForm from "$lib/components/LoginForm.svelte";
     import Hero from "$lib/components/Hero.svelte";
+	import { onMount } from "svelte";
 
     export let form;
+
+    onMount(() => {
+
+        const handleClickOutside = (e: any) => {
+            let rfidInput = document.getElementById('rfidInput'); //take the rfid input
+            const target = e.target;    //take the target of the event
+            const focusedElement = document.activeElement;  //this is the active element being focused
+            
+            // if the current element is rfidInput and you are not clicking an input or a button, do not remove the focus
+            if (focusedElement === rfidInput && !(target instanceof HTMLInputElement || target instanceof HTMLButtonElement)) {
+                e.preventDefault();
+            }
+
+            // if the current element is not the rfidInput and you click anything else, it should focus the rfid input
+            else if(focusedElement !== rfidInput && !(target instanceof HTMLInputElement || target instanceof HTMLButtonElement)) {
+
+                //need to add a delay because of svelte
+                setTimeout(() => {
+                    rfidInput?.focus()
+                }, 1)
+            }  
+        };
+        
+        // when mouse is clicked, call handle click outside
+        document.addEventListener('mousedown', handleClickOutside);
+
+        return () => {
+        document.removeEventListener('mousedown', handleClickOutside);
+        };
+    });
+
 </script>
 
 <section class="flex justify-center items-center lg:h-screen">
+    
+    <input id="rfidInput" autofocus/>
+
     <div 
         class="content grid 
                 lg:grid-cols-12 lg:grid-rows-1 lg:gap-20

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,51 +6,11 @@
 
     export let form;
 
-    onMount(() => {
-        let rfidInput = document.getElementById('rfidInput'); //take the rfid input
-
-        const handleClickOutside = (e: any) => {
-            const target = e.target;    //take the target of the event
-            const focusedElement = document.activeElement;  //this is the active element being focused
-
-            // if the current element is rfidInput and you are not clicking an input or a button, do not remove the focus
-            if (focusedElement === rfidInput && !(target instanceof HTMLInputElement || target instanceof HTMLButtonElement)) {
-                e.preventDefault();
-            }
-
-            // if the current element is not the rfidInput and you click anything else, it should focus the rfid input
-            else if(focusedElement !== rfidInput && !(target instanceof HTMLInputElement || target instanceof HTMLButtonElement)) {
-
-                //need to add a delay because of svelte
-                setTimeout(() => {
-                    rfidInput?.focus()
-                }, 10)
-            }  
-        };
-        
-        const handleKeyDown = (e: any) => {
-            const focusedElement = document.activeElement;  //this is the active element being focused
-            if (rfidInput === focusedElement){
-                console.log()
-                e.preventDefault();
-            }
-        }
-
-        // when mouse is clicked, call handle click outside
-        document.addEventListener('mousedown', handleClickOutside);
-        document.addEventListener('keydown', handleKeyDown);
-
-
-        return () => {
-            document.removeEventListener('mousedown', handleClickOutside);
-        };
-    });
 
 </script>
 
 <section class="flex justify-center items-center lg:h-screen">
     
-    <input id="rfidInput" autofocus/>
 
     <div 
         class="content grid 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,12 +7,12 @@
     export let form;
 
     onMount(() => {
+        let rfidInput = document.getElementById('rfidInput'); //take the rfid input
 
         const handleClickOutside = (e: any) => {
-            let rfidInput = document.getElementById('rfidInput'); //take the rfid input
             const target = e.target;    //take the target of the event
             const focusedElement = document.activeElement;  //this is the active element being focused
-            
+
             // if the current element is rfidInput and you are not clicking an input or a button, do not remove the focus
             if (focusedElement === rfidInput && !(target instanceof HTMLInputElement || target instanceof HTMLButtonElement)) {
                 e.preventDefault();
@@ -24,15 +24,25 @@
                 //need to add a delay because of svelte
                 setTimeout(() => {
                     rfidInput?.focus()
-                }, 1)
+                }, 10)
             }  
         };
         
+        const handleKeyDown = (e: any) => {
+            const focusedElement = document.activeElement;  //this is the active element being focused
+            if (rfidInput === focusedElement){
+                console.log()
+                e.preventDefault();
+            }
+        }
+
         // when mouse is clicked, call handle click outside
         document.addEventListener('mousedown', handleClickOutside);
+        document.addEventListener('keydown', handleKeyDown);
+
 
         return () => {
-        document.removeEventListener('mousedown', handleClickOutside);
+            document.removeEventListener('mousedown', handleClickOutside);
         };
     });
 


### PR DESCRIPTION
Features
- Separated the login options to rfid and username and password
- For the rfid login, the input field will be automatically and permanently selected, even when clicking elsewhere. The keyboard is also disabled. **Note that once this is confirmed to be working, I'll set the input field to invisible.**
- For the username login, it works as intended (no backend yet)

![image](https://github.com/bbcarrots/SUSe/assets/56602966/6a305b65-721b-480c-8baa-f4baaab449bb)
![image](https://github.com/bbcarrots/SUSe/assets/56602966/58625f4c-2c69-444e-bdf7-3134ade08eb0)
