### PR TITLE
fix/backend/dashboard/admin/usagelogs: usage log table should display all active and finished ULs

### DIFF
--- a/src/lib/classes/Admin.ts
+++ b/src/lib/classes/Admin.ts
@@ -21,7 +21,7 @@ export type AdminResponse = {
 export type AdminFilter = {
 	adminID: number;
 	nickname: string;
-	isActive: boolean;
+	isActive: boolean | null;
 };
 
 export class Admin {
@@ -42,7 +42,7 @@ export class Admin {
 		filter: AdminFilter = {
 			adminID: 0,
 			nickname: '',
-			isActive: true
+			isActive: null
 		}
 	): Promise<AdminResponse> {
 		/* Selects all admin records in database using the default or given filter. */

--- a/src/lib/classes/Admin.ts
+++ b/src/lib/classes/Admin.ts
@@ -5,7 +5,6 @@ import type { AdminProcessed } from '$lib/utils/types';
 export type AdminDBObj = {
 	admin_id: number;
 	rfid: number;
-	pw: string;
 	nickname: string;
 	is_active: boolean;
 };
@@ -32,7 +31,6 @@ export class Admin {
 		return {
 			admin_id: admin.adminID,
 			rfid: 0,
-			pw: '',
 			nickname: 'nickname' in admin ? admin.nickname : '',
 			is_active: admin.isActive
 		};

--- a/src/lib/classes/Student.ts
+++ b/src/lib/classes/Student.ts
@@ -35,6 +35,8 @@ export type StudentFilter = {
 	maxStudentNumber: number;
 	username: string;
     rfid: number;
+    isEnrolled: boolean | null;
+    isActive: boolean | null;
 };
 
 export class Student {
@@ -63,7 +65,9 @@ export class Student {
 			minStudentNumber: 2000,
 			maxStudentNumber: new Date().getFullYear(), // gets current year
 			username: '',
-            rfid: 0
+            rfid: 0,
+            isEnrolled: null,
+            isActive: null,
 		}
 	): Promise<StudentResponse> {
 		/* Selects all student records in database using the default or given filter. */

--- a/src/lib/classes/UsageLog.ts
+++ b/src/lib/classes/UsageLog.ts
@@ -14,7 +14,7 @@ export type UsageLogDBObj = {
 	service_id: number;
 	service_type: string;
 	datetime_start: string;
-	datetime_end: string;
+	datetime_end: string | null;
 };
 
 // return value of usage log DB functions
@@ -29,7 +29,7 @@ export type UsageLogFilter = {
 	usageLogID: number;
 	studentNumber: number;
 	minDate: string;
-	maxDate: string;
+	maxDate: string | null;
 };
 
 export class UsageLog {
@@ -53,7 +53,7 @@ export class UsageLog {
 			usageLogID: 0,
 			studentNumber: 0,
 			minDate: new Date(2000).toISOString(), // need to convert to ISOString to filter DB
-			maxDate: new Date().toISOString() // gets date today
+			maxDate: "" // gets date today
 		}
 	): Promise<UsageLogResponse> {
 		/* Selects all usage logs in database using the default or given filter. */

--- a/src/lib/components/TableCell.svelte
+++ b/src/lib/components/TableCell.svelte
@@ -32,7 +32,7 @@
 	{/if}
 
 	{#if field == 'dateTimeStart' || field == 'dateTimeEnd'}
-		<time datetime={value}>{formatDateTime(value)}</time>
+		<time datetime={value}>{value != null ? formatDateTime(value) : null}</time>
 	{:else if field !== 'studentNumber' || !Object.hasOwn(info, 'isEnrolled')}
 		<p>{value}</p>
 	{/if}

--- a/src/lib/server/AdminSB.ts
+++ b/src/lib/server/AdminSB.ts
@@ -69,6 +69,14 @@ async function checkAdminExistsDB(filter: AdminFilter): Promise<AdminResponse> {
 	const adminDB = await selectAdminDB(filter);
 
 	if (adminDB.success && adminDB.adminRaws?.length == 1) {
+        if (adminDB.adminRaws[0].is_active) {
+			return {
+				success: true,
+				adminRaws: null,
+				error: 'Warning: Admin is active.'
+			};
+		}
+
 		return success;
 	}
 
@@ -95,7 +103,7 @@ export async function updateAdminDB(admin: AdminDBObj): Promise<AdminResponse> {
 	const updateObj: { [key: string]: string | boolean } = {};
 
 	for (const [key, value] of Object.entries(admin)) {
-		// updates admin name only
+		// updates admin name and is active
 		if ((value && typeof value == 'string') || typeof value == 'boolean') {
 			updateObj[key] = value;
 		}
@@ -124,7 +132,13 @@ export async function deleteAdminDB(adminID: number): Promise<AdminResponse> {
 
 	if (!adminCheck.success) {
 		return adminCheck;
-	}
+	} else if (adminCheck.error == 'Warning: Admin is active.') {
+        return {
+            success: false,
+            adminRaws: null,
+            error: 'Warning: Admin is active.'
+        };
+    }
 
 	const { error } = await supabase.from('admin').delete().eq('admin_id', adminID);
 

--- a/src/lib/server/AdminSB.ts
+++ b/src/lib/server/AdminSB.ts
@@ -18,7 +18,7 @@ export async function selectAdminDB(filter: AdminFilter): Promise<AdminResponse>
 	/* Selects the admin record/s from the database using a filter.
     Filter contains option for admin ID, nickname, and is active. */
 
-	let query = supabase.from('admin').select('*').eq('is_active', filter.isActive);
+	let query = supabase.from('admin').select('*');
 
 	if (filter.adminID) {
 		query = query.eq('admin_id', filter.adminID);
@@ -27,6 +27,10 @@ export async function selectAdminDB(filter: AdminFilter): Promise<AdminResponse>
 	if (filter.nickname) {
 		query = query.like('admin_name', '%' + filter.nickname + '%');
 	}
+
+    if (filter.isActive != null) {
+        query = query.eq('is_active', filter.isActive);
+    }
 
 	const { data, error } = await query;
 
@@ -81,7 +85,7 @@ export async function updateAdminDB(admin: AdminDBObj): Promise<AdminResponse> {
 	const adminCheck = await checkAdminExistsDB({
 		adminID: admin.admin_id,
 		nickname: '',
-		isActive: false // Admin should be inactive to be updated
+		isActive: null // Admin should be inactive to be updated
 	});
 
 	if (!adminCheck.success) {
@@ -92,7 +96,7 @@ export async function updateAdminDB(admin: AdminDBObj): Promise<AdminResponse> {
 
 	for (const [key, value] of Object.entries(admin)) {
 		// updates admin name only
-		if (value && typeof value == 'string') {
+		if ((value && typeof value == 'string') || typeof value == 'boolean') {
 			updateObj[key] = value;
 		}
 	}
@@ -115,7 +119,7 @@ export async function deleteAdminDB(adminID: number): Promise<AdminResponse> {
 	const adminCheck = await checkAdminExistsDB({
 		adminID: adminID,
 		nickname: '',
-		isActive: false
+		isActive: null
 	});
 
 	if (!adminCheck.success) {

--- a/src/lib/server/AdminSB.ts
+++ b/src/lib/server/AdminSB.ts
@@ -136,7 +136,7 @@ export async function deleteAdminDB(adminID: number): Promise<AdminResponse> {
         return {
             success: false,
             adminRaws: null,
-            error: 'Warning: Admin is active.'
+            error: adminCheck.error
         };
     }
 

--- a/src/lib/server/ServiceSB.ts
+++ b/src/lib/server/ServiceSB.ts
@@ -1,7 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 // import { env } from '$env/dynamic/public';
 import { type ServiceDBObj, type ServiceFilter, type ServiceResponse } from '$lib/classes/Service';
-import { serviceTypes } from '$lib/utils/filterOptions';
 
 // creates the connection to SUSe supabase
 export const supabase = createClient(

--- a/src/lib/server/ServiceSB.ts
+++ b/src/lib/server/ServiceSB.ts
@@ -175,12 +175,10 @@ export async function updateServiceDB(service: ServiceDBObj): Promise<ServiceRes
 
 	for (const [key, value] of Object.entries(service)) {
 		if (
-			(value &&
-				typeof value == 'string' &&
-				key != 'service_id' &&
-				key != 'service_type_id' &&
-				key != 'service_type') ||
-			typeof value == 'boolean'
+			((value && typeof value == 'string') || typeof value == 'boolean') &&
+			key != 'service_id' &&
+			key != 'service_type_id' &&
+			key != 'service_type'
 		) {
 			updateObj[key] = value;
 		}
@@ -209,13 +207,20 @@ export async function deleteServiceDB(serviceID: number): Promise<ServiceRespons
 		serviceID: serviceID,
 		serviceName: '',
 		serviceType: '',
-		inUse: null, // service has to be not in use to be deleted
+		inUse: null,
 		isAdmin: true
 	});
 
-	if (!serviceCheck.success || serviceCheck.error == 'Warning: Service is in use.') {
+	if (!serviceCheck.success) {
 		return serviceCheck;
-	}
+	} else if (serviceCheck.error == 'Warning: Service is in use.') {
+        return {
+			success: false,
+			serviceRaws: null,
+			availableServices: null,
+			error: serviceCheck.error
+		};
+    }
 
 	const { error } = await supabase.from('service').delete().eq('service_id', serviceID);
 

--- a/src/lib/server/UsageLogSB.ts
+++ b/src/lib/server/UsageLogSB.ts
@@ -43,10 +43,7 @@ export async function selectUsageLogDB(filter: UsageLogFilter): Promise<UsageLog
 	if (filter.maxDate) {
 		// if there is a given start and end date range, search for that
 		query = query.lte('datetime_end', filter.maxDate);
-	} 
-    /* else {
-        query = query.is('datetime_end', null);
-    } */
+	}
 
 	const { data, error } = await query;
 

--- a/src/lib/server/UsageLogSB.ts
+++ b/src/lib/server/UsageLogSB.ts
@@ -40,9 +40,11 @@ export async function selectUsageLogDB(filter: UsageLogFilter): Promise<UsageLog
 		query = query.gte('datetime_start', filter.minDate);
 	}
 
-	if (filter.maxDate) {
+	if (filter.maxDate && typeof filter.maxDate == 'string') {
 		// if there is a given start and end date range, search for that
 		query = query.lte('datetime_end', filter.maxDate);
+	} else if (filter.maxDate == null) {
+		query = query.is('datetime_end', null);
 	}
 
 	const { data, error } = await query;
@@ -66,7 +68,7 @@ export async function selectUsageLogDB(filter: UsageLogFilter): Promise<UsageLog
 			service_id: row.service.service_id, // will fix later after tinkering with supabase type returns
 			service_type: row.service.service_type.service_type, // we assume each service only has one service_type
 			datetime_start: row.datetime_start,
-			datetime_end: row.datetime_end
+			datetime_end: row.datetime_end != null ? row.datetime_end : null
 		});
 	}
 
@@ -99,6 +101,14 @@ async function checkUsageLogExistsDB(filter: UsageLogFilter): Promise<UsageLogRe
 	const usageLogDB = await selectUsageLogDB(filter);
 
 	if (usageLogDB.success && usageLogDB.usageLogRaws?.length == 1) {
+        if (usageLogDB.usageLogRaws[0].datetime_end == null) {
+            return {
+                success: true,
+                usageLogRaws: null,
+                error: 'Warning: Usage log is ongoing.'
+            };
+        }
+
 		return success;
 	}
 
@@ -155,7 +165,13 @@ export async function deleteUsageLogDB(usageLogID: number): Promise<UsageLogResp
 
 	if (!usageLogCheck.success) {
 		return usageLogCheck;
-	}
+	} else if (usageLogCheck.error == 'Warning: Usage log is ongoing.') {
+        return {
+            success: false,
+            usageLogRaws: null,
+            error: usageLogCheck.error
+        };
+    }
 
 	const { error } = await supabase.from('usage_log').delete().eq('ul_id', usageLogID);
 

--- a/src/routes/api/avail-end/+server.ts
+++ b/src/routes/api/avail-end/+server.ts
@@ -109,7 +109,7 @@ export async function POST({ request }) {
 		usageLogID: 0,
 		studentNumber: studentNumber,
 		minDate: dateToday,
-		maxDate: ''
+		maxDate: null
 	});
 
 	if (!usageLogSelectResponse.success) {

--- a/src/routes/dashboard/student/home/[studentNumber]/+page.server.ts
+++ b/src/routes/dashboard/student/home/[studentNumber]/+page.server.ts
@@ -11,7 +11,7 @@ export async function load({ params }) {
 		usageLogID: 0,
 		studentNumber: studentNumber,
 		minDate: new Date(dayStart).toISOString(), // need to convert to ISOString to filter DB
-		maxDate: ''
+		maxDate: null
 	});
 
 	const serviceResponse = await Service.selectServices({


### PR DESCRIPTION
@gabrielcalubayan72 Please see changes below.

# Major Changes
- `datetime_end` property of UsageLogDBObj can now be `null`. This is for storing ULs that are ongoing (end date has not been filled out).
- `maxDate` property of UsageLogFilter can now be `null`. This is for selecting ULs that are ongoing. 
 - If `maxDate` is a string, then it looks for a completed UL within the maxDate range.
 - If `maxDate` is "" (empty string), it selects every UL including completed and ongoing.
 - If `maxDate` is null, it selects only the ongoing UL.
- We cannot delete ongoing UsageLogs.
- If an admin edits the end date of an ongoing UL, the student can still edit the end date. (Not really important for anything since we'll be changing this in the future)