### PR TITLE
fix: sort table items first, then truncate

### DIFF
--- a/src/lib/components/Table.svelte
+++ b/src/lib/components/Table.svelte
@@ -26,16 +26,15 @@
 	/* isEditing is binded to the value from TableRow.svelte. */
 	let isEditing: boolean;
 	let sortedItems = writable<Array<any>>([]);
-
+	let calculatedRows = writable<Array<any>>([]);
 	/* Reactively sorts the items and stores in sortedItems based on the sortKey and sortDirection. */
 	/* The sorting will be disabled if isEditing is true. */
 
 	$: {
-		const calculatedRows = info.slice((activePage - 1) * rowsPerPage, activePage * rowsPerPage);
 		const disableSort: boolean = isEditing;
 		const key: string = sortKey;
 		const direction: number = sortDirection;
-		const items: Array<any> = [...calculatedRows];
+		const items: Array<any> = [...info];
 
 		if (!disableSort) {
 			items.sort((a, b) => {
@@ -56,6 +55,10 @@
 			});
 			sortedItems.set(items);
 		}
+
+		calculatedRows.set(
+			$sortedItems.slice((activePage - 1) * rowsPerPage, activePage * rowsPerPage)
+		);
 	}
 
 	// ----------------------------------------------------------------------------------
@@ -100,7 +103,7 @@
 	<Table hoverable={true} divClass="overflow-x-auto">
 		<TableHeader {hide} {headers} bind:sortKey bind:sortDirection {isEditing} />
 		<TableBody>
-			{#each $sortedItems as info}
+			{#each $calculatedRows as info}
 				<TableRow
 					on:approve={forwardApprove}
 					on:delete={forwardDelete}


### PR DESCRIPTION
## Sort table items first before truncating
Sample: sorted service table by service name (pages 1 and 2)

![image](https://github.com/bbcarrots/SUSe/assets/56602966/36e2ef53-7c44-4cbd-9816-774d24de3690)
![image](https://github.com/bbcarrots/SUSe/assets/56602966/6b364e3d-d6e2-4e73-86a8-a644ccc25a64)
