### PR TITLE
fix/frontend/register: cancel button redirect and hover state

### DIFF
--- a/src/lib/components/Button.svelte
+++ b/src/lib/components/Button.svelte
@@ -15,7 +15,7 @@
 <button 
     type={submit ? 'submit' : 'button'}
     class="w-full justify-center gap-2 py-3 px-6 rounded-md hover:bg-suse-black/95 font-medium text-sm inline-flex items-center
-        {inverse ? 'bg-transparent text-suse-black border border-suse-black border-solid hover:bg-suse-black/40' : 'bg-suse-black text-suse-white'}
+        {inverse ? 'bg-transparent text-suse-black border border-suse-black border-solid hover:text-white hover:bg-suse-black/70' : 'bg-suse-black text-suse-white'}
         {small ? 'rounded-[100px] py-2 px-4' : 'py-3 px-6'}
         {disabled ? 'opacity-50 pointer-events-none' : ''}"
     on:click

--- a/src/lib/components/Pill.svelte
+++ b/src/lib/components/Pill.svelte
@@ -5,7 +5,7 @@
 
 <div class="flex items-center">
 	<div
-		class="flex inline-flex items-center justify-between rounded bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-300"
+		class="flex items-center justify-between rounded bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-300"
 	>
 		<p class="m-0">{value}</p>
 		<!-- Removed margin to make the text flush with the container -->

--- a/src/lib/components/RegisterForm.svelte
+++ b/src/lib/components/RegisterForm.svelte
@@ -4,9 +4,14 @@
 	import { enhance } from '$app/forms';
 	import { userRFID } from '$lib/stores/User';
 	import { CollegePrograms } from '$lib/stores/CollegePrograms';
-
+	import { goto } from '$app/navigation';
+	
 	let inputs: NodeListOf<HTMLInputElement | HTMLSelectElement>;
 	let college = 'College of Engineering';
+
+	function handleCancel(){
+		goto('/');
+	}
 
 	onMount(() => {
 		inputs = document.querySelectorAll<HTMLInputElement | HTMLSelectElement>('input, select');
@@ -207,7 +212,7 @@
 
 		<!-- ACTION BUTTONS -->
 		<div class="inline-flex gap-4">
-			<Button inverse={true}>Cancel</Button>
+			<Button inverse={true} on:click={handleCancel}>Cancel</Button>
 			<Button submit={true}>Register</Button>
 		</div>
 	</form>


### PR DESCRIPTION
Fixes
- Cancel button redirects to login page
- Hover state is now more visible (previously the text was also black)

![image](https://github.com/bbcarrots/SUSe/assets/56602966/96b4af4c-5e60-4c11-9f1b-0c28e36fda3e)
